### PR TITLE
Use stable toolchain instead of nightly

### DIFF
--- a/src/hello-world.md
+++ b/src/hello-world.md
@@ -3,7 +3,7 @@
 A basic "hello world" can be generated with:
 
 ```
-$ cargo +nightly new hello-world
+$ cargo new hello-world
 ```
 
 Next up change `Cargo.toml` to have:
@@ -25,7 +25,7 @@ pub extern fn add_one(a: u32) -> u32 {
 Now prepare the wasm binary with:
 
 ```
-$ cargo +nightly build --target wasm32-unknown-unknown --release
+$ cargo build --target wasm32-unknown-unknown --release
 
 # make the binary a little smaller (working around bugs in rustc toolchain)
 $ wasm-gc target/wasm32-unknown-unknown/release/hello_world.wasm -o hello_world.gc.wasm

--- a/src/setup.md
+++ b/src/setup.md
@@ -7,7 +7,7 @@ installed on your machine. Once that's installed you'll need to get the `wasm32-
 toolchain.
 
 ```bash
-$ rustup target add wasm32-unknown-unknown --toolchain nightly
+$ rustup target add wasm32-unknown-unknown
 ```
 
 Next up if you're interested in making small wasm binaries you'll want to


### PR DESCRIPTION
As soon as `wasm32-unknown-unknown` is on stable toolchain since Rust 1.24.0, I think we don't need to refer to nightly anymore.
