### PR TITLE
Update hello-world page to reflect new cargo default

### DIFF
--- a/src/hello-world.md
+++ b/src/hello-world.md
@@ -3,7 +3,7 @@
 A basic "hello world" can be generated with:
 
 ```
-$ cargo +nightly new hello-world
+$ cargo +nightly new --lib hello-world
 ```
 
 Next up change `Cargo.toml` to have:


### PR DESCRIPTION
Hello!

The default crate template when for cargo on nightly has been switched from `--bin` to `--lib` in rust-lang/cargo#5029. When you follow the instructions on the hello-world page you no longer get the `src/lib.rs` file that you are supposed to edit.

This PR updates the cargo command to use the `--lib` flag.