### PR TITLE
Fix http crate name in Hello World walk through

### DIFF
--- a/src/hello-world.md
+++ b/src/hello-world.md
@@ -52,7 +52,7 @@ And we can test it out with:
 </html>
 ```
 
-Note: To run with `instantiateStreaming` and `compileStreaming`, you need your webserver to serve `.wasm` file with `application/wasm` MIME type. The [https](https://github.com/thecoshman/http) crate can be used to serve files from `localhost`, and includes the `application/wasm` MIME type out of the box.
+Note: To run with `instantiateStreaming` and `compileStreaming`, you need your webserver to serve `.wasm` file with `application/wasm` MIME type. The [`http`](https://github.com/thecoshman/http) crate can be used to serve files from `localhost`, and includes the `application/wasm` MIME type out of the box.
 
 Alternatively, if you are running locally without any webserver.
 


### PR DESCRIPTION
The crate name is `http` rather than `https`.