### PR TITLE
Update tutorial for wasm-bindgen 0.2

### DIFF
--- a/src/wasm-pack/initialize.md
+++ b/src/wasm-pack/initialize.md
@@ -49,7 +49,7 @@ repository = "https://github.com/mgattozzi/wasm-add"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen="0.1"
+wasm-bindgen="0.2"
 ```
 
 First off lets look at the last three fields added to the package section `description`, `license`,
@@ -72,7 +72,7 @@ a wasm binary properly. This is meant to get `cargo` to pass the right parameter
 Alright the last thing we added was this to the `[dependencies]` section:
 
 ```toml
-wasm-bindgen="0.1"
+wasm-bindgen="0.2"
 ```
 
 This is the `wasm-bindgen` crate. We'll be using it very shortly to make our functions work nicely

--- a/src/wasm-pack/rust-code.md
+++ b/src/wasm-pack/rust-code.md
@@ -26,15 +26,15 @@ We'll use this later to make sure our `add` function works!
 Now we need to add this to the top of the file:
 
 ```rust
-#![feature(proc_macro)]
+#![feature(proc_macro, wasm_import_module, wasm_custom_section)]
 extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 ```
 
-Let's step through this line by line. First up is the `proc_macro` feature. We're enabling this for
+Let's step through this line by line. First up is the list of nightly features. We're enabling this for
 the whole crate. What this means is that we will later tag code with an attribute and this will
 allow rust to generate code that we don't have to write by hand. In our case it'll use
-`wasm-bindgen.` It should be noted that `#![feature(proc_macro)]` implies using the nightly
+`wasm-bindgen.` It should be noted that `#![feature(...)]` implies using the nightly
 compiler. This gated feature will hopefully be stabilized and landed soon so that you won't need it!
 
 `wasm-bindgen` knows how to make code that works well with wasm so we don't have to
@@ -97,7 +97,7 @@ value was! We then return what was inside `c`. Neat!
 This is all the Rust code we need to write. Your `lib.rs` file should look like this by now:
 
 ```rust
-#![feature(proc_macro)]
+#![feature(proc_macro, wasm_import_module, wasm_custom_section)]
 extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
Update the version number in `Cargo.toml` as well as updating the list of
nightly features