### PR TITLE
s/svelte/twiggy/ -- its been renamed!

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ bundler ecosystem to look something like this:
         * [Design][wasm-bindgen-design]
         * [Open Issues][wasm-bindgen-issues]
 
-    * [`svelte` is a work-in-progress code size profiler for WebAssembly.][svelte]
-        * [Contributing][svelte-contributing]
-        * [Open Issues][svelte-issues]
+    * [`twiggy` is a work-in-progress code size profiler for WebAssembly.][twiggy]
+        * [Contributing][twiggy-contributing]
+        * [Open Issues][twiggy-issues]
 
 * Take a look at [this repo's open issues][issues]
 
@@ -95,9 +95,9 @@ bundler ecosystem to look something like this:
 [wasm-bindgen]: https://github.com/alexcrichton/wasm-bindgen
 [wasm-bindgen-design]: https://github.com/alexcrichton/wasm-bindgen/blob/master/DESIGN.md
 [wasm-bindgen-issues]: https://github.com/alexcrichton/wasm-bindgen/issues
-[svelte]: https://github.com/fitzgen/svelte
-[svelte-contributing]: https://github.com/fitzgen/svelte/blob/master/CONTRIBUTING.md
-[svelte-issues]: https://github.com/fitzgen/svelte/issues
+[twiggy]: https://github.com/rustwasm/twiggy
+[twiggy-contributing]: https://github.com/rustwasm/twiggy/blob/master/CONTRIBUTING.md
+[twiggy-issues]: https://github.com/rustwasm/twiggy/issues
 
 # Status
 

--- a/src/game-of-life/code-size.md
+++ b/src/game-of-life/code-size.md
@@ -112,9 +112,9 @@ remaining code size is coming from.
 > let size profiling guide our code size shrinking efforts. Fail to do this and
 > you risk wasting your own time!
 
-### The `svelte` Code Size Profiler
+### The `twiggy` Code Size Profiler
 
-[`svelte` is a code size profiler][svelte] that supports WebAssembly as
+[`twiggy` is a code size profiler][twiggy] that supports WebAssembly as
 input. It analyzes a binary's call graph to answer questions like:
 
 * Why was this function included in the binary in the first place?
@@ -123,7 +123,7 @@ input. It analyzes a binary's call graph to answer questions like:
   saved if I removed it and all the functions that become dead code after its
   removal?
 
-*Note: `svelte` will change its name soon and move into the `rustwasm` Github
+*Note: `twiggy` will change its name soon and move into the `rustwasm` Github
 organization.*
 
 <style>
@@ -135,7 +135,7 @@ pre, code {
 </style>
 
 ```text
-$ svelte top -n 20 wasm_game_of_life_bg.wasm
+$ twiggy top -n 20 wasm_game_of_life_bg.wasm
  Shallow Bytes │ Shallow % │ Item
 ───────────────┼───────────┼────────────────────────────────────────────────────────────────────────────────────────
           9158 ┊    19.65% ┊ "function names" subsection
@@ -160,7 +160,7 @@ $ svelte top -n 20 wasm_game_of_life_bg.wasm
            503 ┊     1.08% ┊ <&'a T as core::fmt::Debug>::fmt::hba207e4f7abaece6
 ```
 
-[svelte]: https://github.com/fitzgen/svelte
+[twiggy]: https://github.com/rustwasm/twiggy
 
 ### Manually Inspecting LLVM-IR
 
@@ -205,7 +205,7 @@ only do string formatting in debug mode, and in release mode use static strings.
 
 ### Avoid Panicking
 
-This is definitely easier said than done, but tools like `svelte` and manually
+This is definitely easier said than done, but tools like `twiggy` and manually
 inspecting LLVM-IR can help you figure out which functions are panicking.
 
 Panics do not always appear as a `panic!()` macro invocation. They arise


### PR DESCRIPTION
No more name clash with the JS framework.