### PR TITLE
Minor grammar edit.

### DIFF
--- a/src/wasm-pack/initialize.md
+++ b/src/wasm-pack/initialize.md
@@ -78,4 +78,4 @@ wasm-bindgen="0.2"
 This is the `wasm-bindgen` crate. We'll be using it very shortly to make our functions work nicely
 with wasm and not have to worry about a lot of nitty gritty details.
 
-We've got our package's metadata all setup so let's actually write some code!
+We've got our package's metadata all set up, so let's actually write some code!


### PR DESCRIPTION
Fixed a minor typo. "Setup" is technically a noun, as opposed to the verb "set up," which I believe is the more appropriate phrase for this sentence.

There is a note regarding this difference here: https://www.merriam-webster.com/dictionary/setup

```
The noun setup is usually styled as a solid compound (that is, as a single word) in American English and as a hyphenated compound (set-up) in British English. The noun may be used attributively (that is, as an adjective) in such phrases as [...] setup tool (“software that facilitates the installation of a computer program”). The verb set up, on the other hand, is usually found as an open compound (two words, no hyphen) in both American and British English.
```