### PR TITLE
Fixed logic in Universe::get_index

### DIFF
--- a/src/game-of-life/implementing.md
+++ b/src/game-of-life/implementing.md
@@ -183,7 +183,7 @@ into an index into the cells vector, as described earlier:
 ```rust
 impl Universe {
     fn get_index(&self, row: u32, column: u32) -> usize {
-        (row * self.height + column) as usize
+        (row * self.width + column) as usize
     }
 
     // ...

--- a/src/game-of-life/implementing.md
+++ b/src/game-of-life/implementing.md
@@ -127,7 +127,7 @@ To find the array index of the cell at a given row and column in the universe,
 we can use this formula:
 
 ```text
-index(row, column, universe) = row * height(universe) + column
+index(row, column, universe) = row * width(universe) + column
 ```
 
 To expose the universe's cells to JavaScript, we return a pointer to the start

--- a/src/game-of-life/implementing.md
+++ b/src/game-of-life/implementing.md
@@ -432,7 +432,7 @@ import { memory } from "./wasm_game_of_life_bg";
 // ...
 
 const getIndex = (row, column) => {
-  return row * height + column;
+  return row * width + column;
 };
 
 const drawCells = () => {


### PR DESCRIPTION
This probably went unnoticed because we almost always have the width and height equal for game of life.