### PR TITLE
Fix incorrect `npm run serve` command

### DIFF
--- a/src/game-of-life/implementing.md
+++ b/src/game-of-life/implementing.md
@@ -480,7 +480,7 @@ npm run build-debug
 Make sure your development server is still running. If it isn't, start it again:
 
 ```
-npm run server
+npm run serve
 ```
 
 If you refresh [http://localhost:8080/](http://localhost:8080/), you should be


### PR DESCRIPTION
Running `npm run server` gives you an error. Went back in the book to find the correct command and it is `npm run serve` :).