### PR TITLE
Remove `--version` from wasm-bindgen CLI install

### DIFF
--- a/src/game-of-life/setup.md
+++ b/src/game-of-life/setup.md
@@ -44,7 +44,7 @@ Rust and WebAssembly.
 Install `wasm-bindgen` with this command:
 
 ```
-cargo +nightly install wasm-bindgen-cli --version 0.2.1
+cargo +nightly install wasm-bindgen-cli
 ```
 
 [wb]: https://github.com/rustwasm/wasm-bindgen


### PR DESCRIPTION
Unfortunately historical versions of the CLI aren't always compatible with
future versions of the crate, so it's best to keep everything up to date for the
time being. This'll hopefully avoid issues like rustwasm/wasm-bindgen#143.