### PR TITLE
Fix broken setup link on wasm-pack setup page.

### DIFF
--- a/src/wasm-pack/setup.md
+++ b/src/wasm-pack/setup.md
@@ -2,8 +2,9 @@
 
 ## Rust
 
-If you haven't already you'll need to install Rust! See [the setup section](../setup.html) for more
-details. Once you've done that you'll need to install `wasm-pack`.
+If you haven't already you'll need to install Rust! See
+[the setup section](https://rust-lang-nursery.github.io/rust-wasm/setup.html)
+for more details. Once you've done that you'll need to install `wasm-pack`.
 
 Just run the following:
 


### PR DESCRIPTION
The [wasm-pack setup page](https://rust-lang-nursery.github.io/rust-wasm/wasm-pack/setup.html) contains a link to the [rust-wasm setup page](https://rust-lang-nursery.github.io/rust-wasm/setup.html) that is currently broken. For some reason, the relative link does not seem to work correctly. This commit replaces the relative path with a direct link.