### PR TITLE
Don't use "./node_modules/" in the import path

### DIFF
--- a/src/wasm-pack/run-the-code.md
+++ b/src/wasm-pack/run-the-code.md
@@ -65,7 +65,7 @@ We're almost set. Now we need to setup our JS file so that we can run some wasm 
 Make a file called `index.js` and put this inside of it:
 
 ```javascript
-const js = import("./node_modules/@MYSCOPE/wasm-add/wasm_add.js");
+const js = import("@MYSCOPE/wasm-add/wasm_add.js");
 js.then(js => {
   js.alert_add(3,2);
 });


### PR DESCRIPTION
When using webpack, modules from dependencies are usually not included through their actual paths on the file system. Instead, the include path starts with the name of the module and it's webpack's job to find the correct directory.

On the other hand, having the full path here is nice because it tells the reader where to go looking for the actual files that wasm-pack produced. So I'm not sure if this is a good change.